### PR TITLE
Rebuild database queries to use parameterisation

### DIFF
--- a/db/create_example_db.sql
+++ b/db/create_example_db.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `usertable` (
+  `user_id` int(11) NOT NULL AUTO_INCREMENT,
+  `doge_spend` decimal(20,8) NOT NULL DEFAULT '0.00000000',
+  `doge_received` decimal(20,8) NOT NULL DEFAULT '0.00000000',
+  `doge_withdraw` decimal(20,8) NOT NULL DEFAULT '0.00000000',
+  `doge_available` decimal(20,8) NOT NULL DEFAULT '0.00000000',
+  `doge_deposit` decimal(20,8) NOT NULL DEFAULT '0.00000000',
+  `doge_address` varchar(35) DEFAULT NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB;

--- a/dogeframe_settings.php
+++ b/dogeframe_settings.php
@@ -4,9 +4,9 @@
 		//wallet connection data (RPC)
 		"rpc_ip" 			=> "localhost",		
 		"rpc_port"			=> 22555,
-		"rpc_user" 			=> "user",
+		"rpc_user" 			=> "dogecoinrpc",
 		"rpc_password" 		=> "password",
-		"rpc_protocol"		=> "https"			//if, for some reason, you can't use https to connect to the wallet, enter "http" here
+		"rpc_protocol"		=> "https",			//if, for some reason, you can't use https to connect to the wallet, enter "http" here
 		
 		//database information
 		"db_server" 		=> "localhost",

--- a/test/create_user.php
+++ b/test/create_user.php
@@ -1,0 +1,30 @@
+<?php
+
+require "dogecoin.php";
+
+$settings = [
+	//wallet connection data (RPC)
+	"rpc_ip" 		=> "localhost",		
+	"rpc_port"		=> 44555,
+	"rpc_user" 		=> "dogecoinrpc",
+	"rpc_password" 		=> "password",
+	"rpc_protocol"		=> "https",
+
+	//database information
+	"db_server" 		=> 'localhost',
+	"db_username"		=> "root",
+	"db_password" 		=> "",
+	"db_database" 		=> "DogeFrame"
+];
+	
+$mysqli = mysqli_connect($settings['db_server'] , $settings['db_username'], $settings['db_password'], $settings['db_database']);
+$dogecoin = new Dogecoin($settings['rpc_user'], $settings['rpc_password'], $settings['rpc_ip'], $settings['rpc_port'], $settings['rpc_protocol'] );
+$address = $dogecoin->getnewaddress('DogeFrame');
+if ($stmt = $mysqli->prepare('INSERT IGNORE INTO usertable (doge_address) VALUES (?)')) {
+	$stmt->bind_param("s", $address);
+	if (!$stmt->execute()) {
+		throw new Exception($mysql->error);
+	}
+	$stmt->close();
+}
+?>

--- a/test/get_address.sql
+++ b/test/get_address.sql
@@ -1,0 +1,8 @@
+<?php
+
+require "dogeframe.php";
+
+$dogeframe = new Dogeframe();
+$balance = $dogeframe->depositAddress(1);
+echo $balance . "\n";
+?>

--- a/test/get_balance.sql
+++ b/test/get_balance.sql
@@ -1,0 +1,8 @@
+<?php
+
+require "dogeframe.php";
+
+$dogeframe = new Dogeframe();
+$balance = $dogeframe->getBalance(1);
+echo $balance . "\n";
+?>


### PR DESCRIPTION
Change the balance fetching and address lookup queries to use query parameterization. This eliminates any risk of injection attacks by providing the parameters in a structured way to the database driver.
Added more detailed tests as queries are executed, to ensure failures are not silently ignored.
Added example database schema.
Added test cases to help test DogeFrame

Blah
